### PR TITLE
remove unnecessary $ from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Outlined as the [Advanced Installation](https://docs.openshift.org/latest/instal
 After logging in with `oc login` (default username/password: openshift), if you don't have a project setup all ready, go ahead and take care of that:
 
         $ oc new-project nodejs-echo \
-        $ --display-name="nodejs" --description="Sample Node.js app"
+        --display-name="nodejs" --description="Sample Node.js app"
 
 That's it, project has been created.  Though it would probably be good to set your current project to this (thought new-project does it automatically as well), such as:
 
@@ -179,7 +179,7 @@ Now navigate to the newly created Node.js web app at the hostname we just config
 You may have noticed the index page "Page view count" reads "No database configured". Let's fix that by adding a MongoDB service. We could use the second OpenShift template example (`nodejs-mongodb.json`) but for the sake of demonstration let's point `oc new-app` at a DockerHub image:
 
         $ oc new-app centos/mongodb-26-centos7 \
-        $ -e MONGODB_USER=admin,MONGODB_DATABASE=mongo_db,MONGODB_PASSWORD=secret,MONGODB_ADMIN_PASSWORD=super-secret
+          -e MONGODB_USER=admin,MONGODB_DATABASE=mongo_db,MONGODB_PASSWORD=secret,MONGODB_ADMIN_PASSWORD=super-secret
 
 The `-e` flag sets the environment variables we want used in the configuration of our new app.
 


### PR DESCRIPTION
There is no need for the `$` on the second line. Also, it stops the user from copying and pasting the command.