### PR TITLE
move openshift templates off of EOL nodejs 8

### DIFF
--- a/openshift/templates/nodejs-mongodb-persistent.json
+++ b/openshift/templates/nodejs-mongodb-persistent.json
@@ -451,8 +451,8 @@
     {
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
-      "description": "Version of NodeJS image to be used (6, 8, or latest).",
-      "value": "8",
+      "description": "Version of NodeJS image to be used (10, 12, or latest).",
+      "value": "12",
       "required": true
     },
     {

--- a/openshift/templates/nodejs-mongodb.json
+++ b/openshift/templates/nodejs-mongodb.json
@@ -435,8 +435,8 @@
     {
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
-      "description": "Version of NodeJS image to be used (6, 8, or latest).",
-      "value": "8",
+      "description": "Version of NodeJS image to be used (10, 12, or latest).",
+      "value": "10",
       "required": true
     },
     {

--- a/openshift/templates/nodejs-mongodb.json
+++ b/openshift/templates/nodejs-mongodb.json
@@ -436,7 +436,7 @@
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
       "description": "Version of NodeJS image to be used (10, 12, or latest).",
-      "value": "10",
+      "value": "12",
       "required": true
     },
     {


### PR DESCRIPTION
@phracek @pkubatrh @hhorak PTAL

I've patched the templates in the openshift 4.x samples operator in the interim