### PR TITLE
Default NODEJS_VERSION to 10

### DIFF
--- a/openshift/templates/nodejs-mongodb-persistent.json
+++ b/openshift/templates/nodejs-mongodb-persistent.json
@@ -452,7 +452,7 @@
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
       "description": "Version of NodeJS image to be used (10, 12, or latest).",
-      "value": "12",
+      "value": "10",
       "required": true
     },
     {


### PR DESCRIPTION
Required for e2e tests when OCP version < 4.4 and where we didn't provide nodejs:12 imagestream