### PR TITLE
chore: remove the reference to node 10 and start using ubi images

### DIFF
--- a/openshift/templates/nodejs.json
+++ b/openshift/templates/nodejs.json
@@ -234,8 +234,8 @@
     {
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
-      "description": "Version of NodeJS image to be used (10, 12, or latest).",
-      "value": "12",
+      "description": "Version of NodeJS image to be used (12-ubi8, 14-ubi8, or latest).",
+      "value": "14-ubi8",
       "required": true
     },
     {


### PR DESCRIPTION
This is part of https://issues.redhat.com/browse/NODE-1277 where we are trying to get rid of the references to node 10 since it is is no longer supported.